### PR TITLE
stackableQuantity; blacklistRegexPattern; fix patch to not change index

### DIFF
--- a/GameData/KSP_PartVolume/PartBlacklist.cfg
+++ b/GameData/KSP_PartVolume/PartBlacklist.cfg
@@ -1,11 +1,19 @@
 //
 // There can be multiple files like this
 //
-// Just list each part to be blacklisted on a separate line
+// key blacklistPart         - name of a part to be blacklisted. 
+// Supports multiple keys.   
 //
+// key blacklistRegexPattern - if part name match the regex, the part will be blacklisted.
+// Supports multiple keys.   
+// https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference
+//
+
 PARTVOLUME_BLACKLIST
 {
 	blacklistPart = flag
+	blacklistPart = PotatoRoid
+	blacklistPart = PotatoComet
 	blacklistPart = launchClamp1
 	blacklistPart = cryoengine-iguanodon-1
 	blacklistRegexPattern = ^kerbalEVA.*$

--- a/GameData/KSP_PartVolume/PartBlacklist.cfg
+++ b/GameData/KSP_PartVolume/PartBlacklist.cfg
@@ -6,5 +6,7 @@
 PARTVOLUME_BLACKLIST
 {
 	blacklistPart = flag
+	blacklistPart = launchClamp1
 	blacklistPart = cryoengine-iguanodon-1
+	blacklistRegexPattern = ^kerbalEVA.*$
 }

--- a/GameData/KSP_PartVolume/PartWhitelist.cfg
+++ b/GameData/KSP_PartVolume/PartWhitelist.cfg
@@ -1,7 +1,8 @@
 //
 // There can be multiple files like this
 //
-// Just list each part to be blacklisted on a separate line
+// Just list each part to be whitelisted on a separate line
+// Whitelisted parts will be process despite any settings
 //
 // The line below is commented out, but there as an example of the syntax
 //

--- a/GameData/KSP_PartVolume/PluginData/KSP_PartVolume.cfg
+++ b/GameData/KSP_PartVolume/PluginData/KSP_PartVolume.cfg
@@ -1,5 +1,6 @@
 PARTVOLUME
 {
+	enableFillers = True
 	filler = 0.1
 	scienceFiller = 0.25
 	engineFiller = 0.15

--- a/GameData/KSP_PartVolume/PluginData/KSP_PartVolume.cfg
+++ b/GameData/KSP_PartVolume/PluginData/KSP_PartVolume.cfg
@@ -3,10 +3,14 @@ PARTVOLUME
 	filler = 0.1
 	scienceFiller = 0.25
 	engineFiller = 0.15
-	rcsFiller = 0.2
-	dotanks = false
-	limitSize = true
+	rcsFiller = 0.20
+	doTanks = False
+	limitSize = True
 	largestAllowablePart = 64000
-	manned = false
-	doStock = false
+	manned = False
+	doStock = False
+	processManipulableOnly = False
+	stackParts = False
+	maxPartsInStack = 4
+	maxStackCommonVolume = 60
 }

--- a/KSP_PartVolume/PartVolume.cs
+++ b/KSP_PartVolume/PartVolume.cs
@@ -285,7 +285,7 @@ namespace KSP_PartVolume
                                 stringBuilder.AppendLine("        packedVolume = " + adjVol.ToString("F0"));
                             }
 
-                            if (stackableQuantity > 1)
+                            if (Settings.stackParts && stackableQuantity > 1)
                             {
                                 stringBuilder.AppendLine("        %stackableQuantity = " + stackableQuantity);
                             }

--- a/KSP_PartVolume/PartVolume.cs
+++ b/KSP_PartVolume/PartVolume.cs
@@ -119,98 +119,107 @@ namespace KSP_PartVolume
                 {
                     AvailablePart current = partEnumerator.Current;
 
+                    string[] urlParts = current.partUrl.Split('/');
+                    string urlName = urlParts[urlParts.Length - 1];
+
                     //
-                    // Don't do the flag or any kerbalEVA
+                    // urlName more precisely correspond to part name in the config than current.name,
+                    // but KerbalEVA and flag have empty urlname and need to be filtered, so: 
                     //
 
+                    string partName = urlParts[urlParts.Length - 1];
+                    if (partName == "") partName = current.name;
 
-                    if (!partBlacklist.Contains(current.name) &&
-                        !Regex.IsMatch(current.name, blacklistRegexPattern) &&
-                        (current.name.Length < 9 || current.name.Substring(0, 9) != "kerbalEVA"))
+                    if (partBlacklist.Contains(partName) ||
+                        Regex.IsMatch(partName, blacklistRegexPattern))
                     {
-                        bool contains_ModuleCargoPart = false;
-                        bool contains_ModuleInventoryPart = false;
-                        bool contains_KSPPartVolumeModule = false;
+                        Log.Info(String.Format("partName: {0, -40} found in the blacklist and ignored.", partName + ","));
+                        continue;
+                    }
 
-                        bool containsCrew = false;
-                        bool isTank = false;
-                        bool sizeTooBig = false;
-                        bool isStock = false;
+                    bool contains_ModuleCargoPart = false;
+                    bool contains_ModuleInventoryPart = false;
+                    bool contains_KSPPartVolumeModule = false;
 
-                        bool isRcsPart = false;
-                        bool isEnginePart = false;
-                        ConfigNode currentCargoPart = null;
+                    bool containsCrew = false;
+                    bool isTank = false;
+                    bool sizeTooBig = false;
+                    bool isStock = false;
 
-                        string[] urlParts = current.partUrl.Split('/');
+                    bool isRcsPart = false;
+                    bool isEnginePart = false;
+                    ConfigNode currentCargoPart = null;
 
-                        if (!Settings.doStock)
+
+
+                    if (!Settings.doStock)
+                    {
+                        if (urlParts[0] == "Squad" || urlParts[0] == "SquadExpansion")
+                            if (!partWhitelist.Contains(partName))
+                                isStock = true;
+                    }
+                    var moduleNodes = current.partConfig.GetNodes("MODULE");
+                    for (int i = 0; i < moduleNodes.Length; i++)
+                    {
+                        var name = moduleNodes[i].GetValue("name");
+
+                        if (name == "ModuleCargoPart")
                         {
-                            if (urlParts[0] == "Squad" || urlParts[0] == "SquadExpansion")
-                                if (!partWhitelist.Contains(urlParts[urlParts.Length - 1]))
-                                    isStock = true;
+                            contains_ModuleCargoPart = true;
+                            currentCargoPart = moduleNodes[i];
                         }
-                        var moduleNodes = current.partConfig.GetNodes("MODULE");
-                        for (int i = 0; i < moduleNodes.Length; i++)
+                        if (name == "ModuleInventoryPart")
+                            contains_ModuleInventoryPart = true;
+                        if (name == "KSPPartVolumeModule") contains_KSPPartVolumeModule = true;
+                        if (name == "ModuleRCS" || name == "ModuleRCSFX") isRcsPart = true;
+                        if (name == "ModuleEngines" || name == "ModuleEnginesFX") isEnginePart = true;
+
+                        //  Check for manned
+                        if (!Settings.manned)
                         {
-                            var name = moduleNodes[i].GetValue("name");
-
-                            if (name == "ModuleCargoPart")
+                            int CrewCapacity = 0;
+                            if (current.partConfig.TryGetValue("CrewCapacity", ref CrewCapacity))
                             {
-                                contains_ModuleCargoPart = true;
-                                currentCargoPart = moduleNodes[i];
-                            }
-                            if (name == "ModuleInventoryPart")
-                                contains_ModuleInventoryPart = true;
-                            if (name == "KSPPartVolumeModule") contains_KSPPartVolumeModule = true;
-                            if (name == "ModuleRCS" || name == "ModuleRCSFX") isRcsPart = true;
-                            if (name == "ModuleEngines" || name == "ModuleEnginesFX") isEnginePart = true;
-
-                            //  Check for manned
-                            if (!Settings.manned)
-                            {
-                                int CrewCapacity = 0;
-                                if (current.partConfig.TryGetValue("CrewCapacity", ref CrewCapacity))
-                                {
-                                    if (CrewCapacity > 0)
-                                        containsCrew = true;
-                                }
+                                if (CrewCapacity > 0)
+                                    containsCrew = true;
                             }
                         }
-                        if (contains_KSPPartVolumeModule)
-                            contains_ModuleCargoPart = false;
-                        var resNodes = current.partConfig.GetNodes("RESOURCE");
-                        float mass = 0;
-                        current.partConfig.TryGetValue("mass", ref mass);
-                        float totalResMass = 0;
+                    }
+                    if (contains_KSPPartVolumeModule)
+                        contains_ModuleCargoPart = false;
+                    var resNodes = current.partConfig.GetNodes("RESOURCE");
+                    float mass = 0;
+                    current.partConfig.TryGetValue("mass", ref mass);
+                    float totalResMass = 0;
 
-                        if (!Settings.doTanks)
+                    if (!Settings.doTanks)
+                    {
+                        foreach (var resNode in resNodes)
                         {
-                            foreach (var resNode in resNodes)
+                            var name = resNode.GetValue("name");
+
+                            if (resourceBlackList.Contains(name))
+                                continue;
+
+                            float maxAmount = 0;
+                            resNode.TryGetValue("maxAmount", ref maxAmount);
+                            var definition = PartResourceLibrary.Instance.GetDefinition(name);
+                            if (definition != null)
                             {
-                                var name = resNode.GetValue("name");
-
-                                if (resourceBlackList.Contains(name))
-                                    continue;
-
-                                float maxAmount = 0;
-                                resNode.TryGetValue("maxAmount", ref maxAmount);
-                                var definition = PartResourceLibrary.Instance.GetDefinition(name);
-                                if (definition != null)
-                                {
-                                    var density = definition.density;
-                                    float resMass = maxAmount * density;
-                                    totalResMass += resMass;
-                                }
+                                var density = definition.density;
+                                float resMass = maxAmount * density;
+                                totalResMass += resMass;
                             }
-
-                            if (totalResMass > mass)
-                                isTank = true;
                         }
-                        stringBuilder = new StringBuilder();
 
-                        Bounds bounds = default(Bounds);
-                        foreach (Bounds rendererBound in PartGeometryUtil.GetRendererBounds((Part)current.partPrefab))
-                            bounds.Encapsulate(rendererBound);
+                        if (totalResMass > mass)
+                            isTank = true;
+                    }
+                    stringBuilder = new StringBuilder();
+
+                    Bounds bounds = default(Bounds);
+                    foreach (Bounds rendererBound in PartGeometryUtil.GetRendererBounds((Part)current.partPrefab))
+                        bounds.Encapsulate(rendererBound);
 
 #if false
                         Bounds colliderBounds = default(Bounds);
@@ -222,168 +231,170 @@ namespace KSP_PartVolume
                         allBounds = PartGeometryUtil.MergeBounds(a, current.iconPrefab.transform.root);
 #endif
 
-                        float vol = (float)(bounds.size.x * bounds.size.y * bounds.size.z) * 1000f;
+                    float vol = (float)(bounds.size.x * bounds.size.y * bounds.size.z) * 1000f;
 
-                        if (vol > Settings.largestAllowablePart && Settings.limitSize)
-                            sizeTooBig = true;
+                    if (vol > Settings.largestAllowablePart && Settings.limitSize)
+                        sizeTooBig = true;
 
-                        var adjVol = AdjustedVolume(current, vol, isEnginePart, isRcsPart, out float adj);
+                    var adjVol = AdjustedVolume(current, vol, isEnginePart, isRcsPart, out float adj);
 
-                        int stackableQuantity = Math.Min((int)Settings.maxCommonStackVolume / (int)adjVol, Settings.maxPartsInStack);
+                    int stackableQuantity = Math.Min((int)Settings.maxCommonStackVolume / (int)adjVol, Settings.maxPartsInStack);
 
-                        bool isManipulableOnly = false;
-                        bool isKSP_PartVolumeModule = false;
-                        string currentCargoPartPackedVolume = "";
+                    bool isManipulableOnly = false;
+                    bool isKSP_PartVolumeModule = false;
+                    string currentCargoPartPackedVolume = "";
 
-                        if (currentCargoPart != null)
+                    if (currentCargoPart != null)
+                    {
+                        if (currentCargoPart.HasValue("packedVolume"))
                         {
-                            Log.Info("currentCargoPart: " + current.name);
-                            if (currentCargoPart.HasValue("packedVolume"))
-                            {
-                                currentCargoPartPackedVolume = currentCargoPart.GetValue("packedVolume");
-                                currentCargoPart.SetValue("packedVolume", adjVol.ToString("F0"));
-                                Log.Info("currentCargoPart: packedVolume: " + currentCargoPartPackedVolume + ", newPackedVolume: " + adjVol);
+                            currentCargoPartPackedVolume = currentCargoPart.GetValue("packedVolume");
+                            currentCargoPart.SetValue("packedVolume", adjVol.ToString("F0"));
 
-                                var v = float.Parse(currentCargoPartPackedVolume);
-                                if (v <= 0)
-                                    isManipulableOnly = true;
+                            Log.Info(String.Format("partName: {0, -40} packedVolume: {1,7}, calcPackedVolume: {2,7:F0}", 
+                                partName + ",", currentCargoPartPackedVolume, adjVol));
 
-                                isKSP_PartVolumeModule = currentCargoPart.HasValue("KSP_PartVolume");
-                            }
-                            else
-                                Log.Error("packedVolume not found");
+                            var v = float.Parse(currentCargoPartPackedVolume);
+                            if (v <= 0)
+                                isManipulableOnly = true;
+
+                            isKSP_PartVolumeModule = currentCargoPart.HasValue("KSP_PartVolume");
                         }
-                        if (contains_ModuleInventoryPart)
-                            adjVol = -1;
+                        else
+                        {
+                            Log.Error(String.Format("partName: {0, -40} packedVolume not found", partName + "," ));
+                        }
+                    }
+                    if (contains_ModuleInventoryPart)
+                        adjVol = -1;
 
-                        StringBuilder tmp = new StringBuilder();
-                        tmp.AppendLine("// " + current.partUrl);
+                    StringBuilder tmp = new StringBuilder();
+                    tmp.AppendLine("// " + current.partUrl);
 
-                        tmp.AppendLine("// Dimensions: x: " + bounds.size.x.ToString("F2") + ", y: " + bounds.size.y.ToString("F2") + ", z: " + bounds.size.z.ToString("F2"));
+                    tmp.AppendLine("// Dimensions: x: " + bounds.size.x.ToString("F2") + ", y: " + bounds.size.y.ToString("F2") + ", z: " + bounds.size.z.ToString("F2"));
 
-                        tmp.AppendLine(string.Format("// Bounding Box Size: {0} liters", vol));
-                        tmp.AppendLine("// Volume adjustment: " + (adj * 100).ToString("F0") + "%");
-                        if (isRcsPart)
-                            tmp.AppendLine("// RCS module detected");
-                        if (isEnginePart)
-                            tmp.AppendLine("// Engine module detected");
-                        tmp.AppendLine("//");
+                    tmp.AppendLine(string.Format("// Bounding Box Size: {0} liters", vol));
+                    tmp.AppendLine("// Volume adjustment: " + (adj * 100).ToString("F0") + "%");
+                    if (isRcsPart)
+                        tmp.AppendLine("// RCS module detected");
+                    if (isEnginePart)
+                        tmp.AppendLine("// Engine module detected");
+                    tmp.AppendLine("//");
 
-                        if (!containsCrew && !isTank && !sizeTooBig && !isStock &&
-                            (!contains_ModuleCargoPart ||
-                             (contains_ModuleCargoPart && Settings.processManipulableOnly && isManipulableOnly) ||
-                           (!isKSP_PartVolumeModule && partWhitelist.Contains(urlParts[urlParts.Length - 1]))
-                            ))
+                    if (!containsCrew && !isTank && !sizeTooBig && !isStock &&
+                        (!contains_ModuleCargoPart ||
+                         (contains_ModuleCargoPart && Settings.processManipulableOnly && isManipulableOnly) ||
+                       (!isKSP_PartVolumeModule && partWhitelist.Contains(partName))
+                        ))
+                    {
+                        stringBuilder.Append(tmp);
+                        string adjName = partName.Replace(' ', '?').Replace('(', '?').Replace(')', '?');
+                        if (contains_ModuleCargoPart)
+                        {
+                            stringBuilder.AppendLine("@PART[" + adjName + "]:HAS[MODULE[ModuleCargoPart]]:Final");
+                            stringBuilder.AppendLine("{");
+                            stringBuilder.AppendLine("    @MODULE[ModuleCargoPart]");
+                            stringBuilder.AppendLine("    {");
+                            stringBuilder.AppendLine("        %packedVolume = " + adjVol.ToString("F0"));
+                        }
+                        else
+                        {
+                            stringBuilder.AppendLine("@PART[" + adjName + "]:HAS[!MODULE[ModuleCargoPart]]:Final");
+                            stringBuilder.AppendLine("{");
+                            stringBuilder.AppendLine("    MODULE");
+                            stringBuilder.AppendLine("    {");
+                            stringBuilder.AppendLine("        name = ModuleCargoPart");
+                            stringBuilder.AppendLine("        packedVolume = " + adjVol.ToString("F0"));
+                        }
+
+                        if (Settings.stackParts && stackableQuantity > 1)
+                        {
+                            stringBuilder.AppendLine("        %stackableQuantity = " + stackableQuantity);
+                        }
+
+                        {
+                            stringBuilder.AppendLine("        %KSP_PartVolume = true");
+                            stringBuilder.AppendLine("    }");
+                            stringBuilder.AppendLine("}");
+                        }
+
+                        RestartWindowVisible = true;
+
+                        Part part = UnityEngine.Object.Instantiate(current.partPrefab);
+                        part.gameObject.SetActive(value: false);
+                        foreach (PartModule m in part.Modules)
+                        {
+                            if (m.moduleName == "ModuleCargoPart")
+                            {
+                                var mcp = m as ModuleCargoPart;
+                                mcp.part = part;
+                                mcp.packedVolume = adjVol;
+
+                                if (stackableQuantity > 1)
+                                    mcp.stackableQuantity = stackableQuantity;
+
+                                for (int i = current.moduleInfos.Count - 1; i >= 0; --i)
+                                {
+                                    AvailablePart.ModuleInfo info = current.moduleInfos[i];
+                                    if (info.moduleName == Localizer.Format("#autoLOC_8002221")) // Cargo Part
+                                    {
+                                        try
+                                        {
+                                            info.info = mcp.GetInfo();
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            Log.Error("PartInfo.Start, Part: " + current.partUrl + ", Exception caught in ModuleCargoPart.GetInfo, exception: " + ex.Message + "\n" + ex.StackTrace);
+                                            info.info = "KSP_PartVolume error";
+                                        }
+                                        break;
+                                    }
+                                }
+
+                            }
+                        }
+                        Destroy(part);
+                    }
+                    else
+                    {
+                        if (!fileExists)
                         {
                             stringBuilder.Append(tmp);
-                            string partName = urlParts[urlParts.Length - 1];
-                            string adjName = partName.Replace(' ', '?').Replace('(', '?').Replace(')', '?');
-                            if (contains_ModuleCargoPart)
-                            {
-                                stringBuilder.AppendLine("@PART[" + adjName + "]:HAS[MODULE[ModuleCargoPart]]:Final");
-                                stringBuilder.AppendLine("{");
-                                stringBuilder.AppendLine("    @MODULE[ModuleCargoPart]");
-                                stringBuilder.AppendLine("    {");
-                                stringBuilder.AppendLine("        %packedVolume = " + adjVol.ToString("F0"));
-                            }
-                            else
-                            {
-                                stringBuilder.AppendLine("@PART[" + adjName + "]:HAS[!MODULE[ModuleCargoPart]]:Final");
-                                stringBuilder.AppendLine("{");
-                                stringBuilder.AppendLine("    MODULE");
-                                stringBuilder.AppendLine("    {");
-                                stringBuilder.AppendLine("        name = ModuleCargoPart");
-                                stringBuilder.AppendLine("        packedVolume = " + adjVol.ToString("F0"));
-                            }
+                            stringBuilder.AppendLine("//   Bypass reasons:");
+                            if (containsCrew)
+                                stringBuilder.AppendLine("//      contains crew ");
+                            if (isTank)
+                                stringBuilder.AppendLine("//      is tank");
+                            if (sizeTooBig)
+                                stringBuilder.AppendLine("//      size exceeds largestAllowablePart: " + Settings.largestAllowablePart);
+                            if (isStock)
+                                stringBuilder.AppendLine("//      is Stock");
+                            if (contains_ModuleCargoPart && !Settings.processManipulableOnly
+                                || contains_ModuleCargoPart && !isManipulableOnly
+                                )
+                                stringBuilder.AppendLine("//      contains ModuleCargoPart (packedVolume = " + currentCargoPartPackedVolume + ")");
 
-                            if (Settings.stackParts && stackableQuantity > 1)
-                            {
-                                stringBuilder.AppendLine("        %stackableQuantity = " + stackableQuantity);
-                            }
+                            stringBuilder.AppendLine("//");
 
-                            {
-                                stringBuilder.AppendLine("        %KSP_PartVolume = true");
-                                stringBuilder.AppendLine("    }");
-                                stringBuilder.AppendLine("}");
-                            }
-
-                            RestartWindowVisible = true;
-
+                            adjVol = -999;
+#if true
+                            current.partConfig.RemoveNode(currentCargoPart);
                             Part part = UnityEngine.Object.Instantiate(current.partPrefab);
                             part.gameObject.SetActive(value: false);
-                            foreach (PartModule m in part.Modules)
-                            {
-                                if (m.moduleName == "ModuleCargoPart")
-                                {
-                                    var mcp = m as ModuleCargoPart;
-                                    mcp.part = part;
-                                    mcp.packedVolume = adjVol;
 
-                                    if (stackableQuantity > 1)
-                                        mcp.stackableQuantity = stackableQuantity;
-
-                                    for (int i = current.moduleInfos.Count - 1; i >= 0; --i)
-                                    {
-                                        AvailablePart.ModuleInfo info = current.moduleInfos[i];
-                                        if (info.moduleName == Localizer.Format("#autoLOC_8002221")) // Cargo Part
-                                        {
-                                            try
-                                            {
-                                                info.info = mcp.GetInfo();
-                                            }
-                                            catch (Exception ex)
-                                            {
-                                                Log.Error("PartInfo.Start, Part: " + current.partUrl + ", Exception caught in ModuleCargoPart.GetInfo, exception: " + ex.Message + "\n" + ex.StackTrace);
-                                                info.info = "KSP_PartVolume error";
-                                            }
-                                            break;
-                                        }
-                                    }
-
-                                }
-                            }
+                            Statics.Check4DelModCargoPart(part);
                             Destroy(part);
-                        }
-                        else
-                        {
-                            if (!fileExists)
-                            {
-                                stringBuilder.Append(tmp);
-                                stringBuilder.AppendLine("//   Bypass reasons:");
-                                if (containsCrew)
-                                    stringBuilder.AppendLine("//      contains crew ");
-                                if (isTank)
-                                    stringBuilder.AppendLine("//      is tank");
-                                if (sizeTooBig)
-                                    stringBuilder.AppendLine("//      size exceeds largestAllowablePart: " + Settings.largestAllowablePart);
-                                if (isStock)
-                                    stringBuilder.AppendLine("//      is Stock");
-                                if (contains_ModuleCargoPart && !Settings.processManipulableOnly
-                                    || contains_ModuleCargoPart && !isManipulableOnly
-                                    )
-                                    stringBuilder.AppendLine("//      contains ModuleCargoPart (packedVolume = " + currentCargoPartPackedVolume + ")");
-
-                                stringBuilder.AppendLine("//");
-
-                                adjVol = -999;
-#if true
-                                current.partConfig.RemoveNode(currentCargoPart);
-                                Part part = UnityEngine.Object.Instantiate(current.partPrefab);
-                                part.gameObject.SetActive(value: false);
-
-                                Statics.Check4DelModCargoPart(part);
-                                Destroy(part);
 #endif
-                            }
                         }
-                        if (!Statics.modifiedParts.ContainsKey(current.partUrl))
-                            Statics.modifiedParts.Add(current.partUrl, new PartModification(stringBuilder, adjVol, adjVol == -999));
-                        else
-                            Log.Error("modifiedParts already contains: " + current.partUrl);
-                        if (!fileExists)
-                            stringBuilder.AppendLine("// ----------------------------------------------------------------------");
-
                     }
+                    if (!Statics.modifiedParts.ContainsKey(current.partUrl))
+                        Statics.modifiedParts.Add(current.partUrl, new PartModification(stringBuilder, adjVol, adjVol == -999));
+                    else
+                        Log.Error("modifiedParts already contains: " + current.partUrl);
+                    if (!fileExists)
+                        stringBuilder.AppendLine("// ----------------------------------------------------------------------");
+
+
                 }
             }
 

--- a/KSP_PartVolume/PartVolume.cs
+++ b/KSP_PartVolume/PartVolume.cs
@@ -269,7 +269,7 @@ namespace KSP_PartVolume
                             string adjName = partName.Replace(' ', '?').Replace('(', '?').Replace(')', '?');
                             if (contains_ModuleCargoPart)
                             {
-                                stringBuilder.AppendLine("@PART[" + adjName + "]:Final");
+                                stringBuilder.AppendLine("@PART[" + adjName + "]:HAS[MODULE[ModuleCargoPart]]:Final");
                                 stringBuilder.AppendLine("{");
                                 stringBuilder.AppendLine("    @MODULE[ModuleCargoPart]");
                                 stringBuilder.AppendLine("    {");
@@ -290,9 +290,11 @@ namespace KSP_PartVolume
                                 stringBuilder.AppendLine("        %stackableQuantity = " + stackableQuantity);
                             }
 
-                            stringBuilder.AppendLine("        KSP_PartVolume = true");
-                            stringBuilder.AppendLine("    }");
-                            stringBuilder.AppendLine("}");
+                            {
+                                stringBuilder.AppendLine("        %KSP_PartVolume = true");
+                                stringBuilder.AppendLine("    }");
+                                stringBuilder.AppendLine("}");
+                            }
 
                             RestartWindowVisible = true;
 
@@ -348,7 +350,7 @@ namespace KSP_PartVolume
                                 if (contains_ModuleCargoPart && !Settings.processManipulableOnly
                                     || contains_ModuleCargoPart && !isManipulableOnly
                                     )
-                                    stringBuilder.AppendLine("//      contains ModuleCargoPart (" + currentCargoPartPackedVolume + ")");
+                                    stringBuilder.AppendLine("//      contains ModuleCargoPart (packedVolume = " + currentCargoPartPackedVolume + ")");
 
                                 stringBuilder.AppendLine("//");
 

--- a/KSP_PartVolume/PartVolume.cs
+++ b/KSP_PartVolume/PartVolume.cs
@@ -291,7 +291,7 @@ namespace KSP_PartVolume
                         string adjName = partName.Replace(' ', '?').Replace('(', '?').Replace(')', '?');
                         if (contains_ModuleCargoPart)
                         {
-                            stringBuilder.AppendLine("@PART[" + adjName + "]:HAS[MODULE[ModuleCargoPart]]:Final");
+                            stringBuilder.AppendLine("@PART[" + adjName + "]:HAS[@MODULE[ModuleCargoPart]]:Final");
                             stringBuilder.AppendLine("{");
                             stringBuilder.AppendLine("    @MODULE[ModuleCargoPart]");
                             stringBuilder.AppendLine("    {");

--- a/KSP_PartVolume/Settings.cs
+++ b/KSP_PartVolume/Settings.cs
@@ -6,6 +6,8 @@ namespace KSP_PartVolume
 {
     class Settings
     {
+
+        public static bool enableFillers = true;
         public static float filler = 0.1f;
         public static float scienceFiller = 0.25f;
         public static float engineFiller = 0.15f;
@@ -20,6 +22,7 @@ namespace KSP_PartVolume
         public static int maxPartsInStack = 4;
         public static float maxCommonStackVolume = 60f;
 
+        public static bool oEnableFillers = enableFillers;
         public static float oFiller = filler;
         public static float oScienceFiller = scienceFiller;
         public static float oEngineFiller = engineFiller;
@@ -36,6 +39,7 @@ namespace KSP_PartVolume
 
         static internal void ResetToDefaults()
         {
+            enableFillers = true;
             filler = 0.1f;
             scienceFiller = 0.25f;
             engineFiller = 0.15f;
@@ -52,6 +56,7 @@ namespace KSP_PartVolume
     }
         static internal void RememberSettings()
         {
+            oEnableFillers = enableFillers;
             oFiller = filler;
             oEngineFiller = engineFiller;
             oRcsFiller = rcsFiller;
@@ -74,6 +79,9 @@ namespace KSP_PartVolume
             ConfigNode node = configNode.GetNode("PARTVOLUME");
             if (node == null)
                 return;
+
+
+            enableFillers = node.SafeLoad("enableFillers", enableFillers);
             filler = node.SafeLoad("filler", filler);
             scienceFiller = node.SafeLoad("scienceFiller", scienceFiller);
             engineFiller = node.SafeLoad("engineFiller", engineFiller);
@@ -93,6 +101,7 @@ namespace KSP_PartVolume
         {
             ConfigNode configNode1 = new ConfigNode();
             ConfigNode configNode2 = new ConfigNode("PARTVOLUME");
+            configNode2.AddValue("enableFillers", enableFillers);
             configNode2.AddValue("filler", filler);
             configNode2.AddValue("scienceFiller", scienceFiller.ToString("F2"));
             configNode2.AddValue("engineFiller", engineFiller.ToString("F2"));
@@ -110,7 +119,8 @@ namespace KSP_PartVolume
             configNode1.AddNode(configNode2);
             configNode1.Save(PartVolume.CFG_FILE);
 
-            if (oEngineFiller != engineFiller ||
+            if (oEnableFillers != enableFillers ||
+                oEngineFiller != engineFiller ||
                 oFiller != filler ||
                 oRcsFiller != rcsFiller ||
                 oScienceFiller != scienceFiller ||

--- a/KSP_PartVolume/Settings.cs
+++ b/KSP_PartVolume/Settings.cs
@@ -16,6 +16,9 @@ namespace KSP_PartVolume
         public static bool manned = false;
         public static bool doStock = false;
         public static bool processManipulableOnly = false;
+        public static bool stackParts = false;
+        public static int maxPartsInStack = 4;
+        public static float maxCommonStackVolume = 60f;
 
         public static float oFiller = filler;
         public static float oScienceFiller = scienceFiller;
@@ -27,6 +30,9 @@ namespace KSP_PartVolume
         public static bool oManned = manned;
         public static bool oDoStock = doStock;
         public static bool oProcessManipulableOnly = processManipulableOnly;
+        public static bool oStackParts = stackParts;
+        public static int oMaxPartsInStack = maxPartsInStack;
+        public static float oMaxStackCommonVolume = maxCommonStackVolume;
 
         static internal void ResetToDefaults()
         {
@@ -40,7 +46,10 @@ namespace KSP_PartVolume
             manned = false;
             doStock = false;
             processManipulableOnly = false;
-        }
+            stackParts = false;
+            maxPartsInStack = 4;
+            maxCommonStackVolume = 60f;
+    }
         static internal void RememberSettings()
         {
             oFiller = filler;
@@ -53,6 +62,9 @@ namespace KSP_PartVolume
             oManned = manned;
             oDoStock = doStock;
             oProcessManipulableOnly = processManipulableOnly;
+            oStackParts = stackParts;
+            oMaxPartsInStack = maxPartsInStack;
+            oMaxStackCommonVolume = maxCommonStackVolume;
         }
         static internal void LoadConfig()
         {
@@ -72,6 +84,9 @@ namespace KSP_PartVolume
             manned = node.SafeLoad("manned", manned);
             doStock = node.SafeLoad("doStock", doStock);
             processManipulableOnly = node.SafeLoad("processManipulableOnly", processManipulableOnly);
+            stackParts = node.SafeLoad("stackParts", stackParts);
+            maxPartsInStack = node.SafeLoad("maxPartsInStack", maxPartsInStack);
+            maxCommonStackVolume = node.SafeLoad("maxStackCommonVolume", maxCommonStackVolume);
         }
 
         static internal void SaveConfig()
@@ -88,6 +103,9 @@ namespace KSP_PartVolume
             configNode2.AddValue("manned", manned);
             configNode2.AddValue("doStock", doStock);
             configNode2.AddValue("processManipulableOnly", processManipulableOnly);
+            configNode2.AddValue("stackParts", stackParts);
+            configNode2.AddValue("maxPartsInStack", maxPartsInStack);
+            configNode2.AddValue("maxStackCommonVolume", maxCommonStackVolume);
 
             configNode1.AddNode(configNode2);
             configNode1.Save(PartVolume.CFG_FILE);
@@ -101,7 +119,11 @@ namespace KSP_PartVolume
                 oLargestAllowablePart != largestAllowablePart ||
                 oManned != manned ||
                 oDoStock != doStock ||
-                oProcessManipulableOnly != processManipulableOnly)
+                oProcessManipulableOnly != processManipulableOnly ||
+                oStackParts != stackParts ||
+                oMaxPartsInStack != maxPartsInStack ||
+                oMaxStackCommonVolume != maxCommonStackVolume
+                )
             {
                 File.Delete(PartVolume.VOL_CFG_FILE);
                 PartVolume.Instance.ShowWarning();

--- a/KSP_PartVolume/SettingsWin.cs
+++ b/KSP_PartVolume/SettingsWin.cs
@@ -63,6 +63,7 @@ namespace KSP_PartVolume
             Settings.doStock = GUILayout.Toggle(Settings.doStock, "Include stock parts");
             Settings.processManipulableOnly = GUILayout.Toggle(Settings.processManipulableOnly, "Process manipulable-only parts");
             Settings.limitSize = GUILayout.Toggle(Settings.limitSize, "Limit Size");
+            Settings.stackParts = GUILayout.Toggle(Settings.stackParts, "Stack Parts");
 
             GUILayout.BeginHorizontal();
             GUILayout.Label("Filler (" + (Settings.filler * 100).ToString("F0") + "%):");
@@ -99,6 +100,33 @@ namespace KSP_PartVolume
                 }
                 GUILayout.EndHorizontal();
             }
+
+            if (Settings.stackParts)
+            {
+                {
+                    GUILayout.BeginHorizontal();
+                    GUILayout.Label("Max Common Stack Volume: ");
+                    var s = GUILayout.TextField(Settings.maxCommonStackVolume.ToString("F0"), GUILayout.Width(50));
+                    GUILayout.Label(" liters");
+                    if (float.TryParse(s, out float f))
+                    {
+                        Settings.maxCommonStackVolume = f;
+                    }
+                    GUILayout.EndHorizontal();
+                }
+                {
+                    GUILayout.BeginHorizontal();
+                    GUILayout.Label("Max Parts In Stack: ");
+                    var s = GUILayout.TextField(Settings.maxPartsInStack.ToString(), GUILayout.Width(50));
+                    GUILayout.Label("");
+                    if (int.TryParse(s, out int i))
+                    {
+                        Settings.maxPartsInStack = i;
+                    }
+                    GUILayout.EndHorizontal();
+                }
+            }
+
             GUILayout.Space(20);
             GUILayout.BeginHorizontal();
             GUILayout.FlexibleSpace();

--- a/KSP_PartVolume/SettingsWin.cs
+++ b/KSP_PartVolume/SettingsWin.cs
@@ -92,7 +92,7 @@ namespace KSP_PartVolume
             {
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Largest Allowable Part: ");
-                var s = GUILayout.TextField(Settings.largestAllowablePart.ToString("F0"), GUILayout.Width(50));
+                var s = GUILayout.TextField(Settings.largestAllowablePart.ToString("F0"), GUILayout.Width(75));
                 GUILayout.Label(" liters");
                 if (float.TryParse(s, out float f))
                 {

--- a/KSP_PartVolume/SettingsWin.cs
+++ b/KSP_PartVolume/SettingsWin.cs
@@ -9,7 +9,7 @@ namespace KSP_PartVolume
     {
         int winId = SpaceTuxUtility.WindowHelper.NextWindowId("PartVolSettings");
         int restartWinId = SpaceTuxUtility.WindowHelper.NextWindowId("restartWinId");
-        Rect partVolSettingsRect = new Rect(0, 0, 400, 150);
+        Rect partVolSettingsRect = new Rect(0, 0, 450, 150);
         Rect RestartWindowRect = new Rect(0, 0, 500, 200);
 
         void Start2()
@@ -58,39 +58,49 @@ namespace KSP_PartVolume
         }
         void ToolbarWindow(int windowID)
         {
+            Settings.enableFillers = GUILayout.Toggle(Settings.enableFillers, "Enable Fillers");
+
+            if (Settings.enableFillers)
+            {
+                GUILayout.BeginHorizontal();
+                GUILayout.Space(50);
+                GUILayout.Label("Filler (" + (Settings.filler * 100).ToString("F0") + "%):");
+                GUILayout.FlexibleSpace();
+                Settings.filler = GUILayout.HorizontalSlider(Settings.filler, 0, 1, GUILayout.Width(250));
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Space(50);
+                GUILayout.Label("Science Filler (" + (Settings.scienceFiller * 100).ToString("F0") + "%):");
+                GUILayout.FlexibleSpace();
+                Settings.scienceFiller = GUILayout.HorizontalSlider(Settings.scienceFiller, 0, 1, GUILayout.Width(250));
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Space(50);
+                GUILayout.Label("Engine Filler (" + (Settings.engineFiller * 100).ToString("F0") + "%):");
+                GUILayout.FlexibleSpace();
+                Settings.engineFiller = GUILayout.HorizontalSlider(Settings.engineFiller, 0, 1, GUILayout.Width(250));
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Space(50);
+                GUILayout.Label("RCS Filler (" + (Settings.rcsFiller * 100).ToString("F0") + "%):");
+                GUILayout.FlexibleSpace();
+                Settings.rcsFiller = GUILayout.HorizontalSlider(Settings.rcsFiller, 0, 1, GUILayout.Width(250));
+                GUILayout.EndHorizontal();
+            }
+
             Settings.doTanks = GUILayout.Toggle(Settings.doTanks, "Include tanks");
             Settings.manned = GUILayout.Toggle(Settings.manned, "Include manned parts");
             Settings.doStock = GUILayout.Toggle(Settings.doStock, "Include stock parts");
             Settings.processManipulableOnly = GUILayout.Toggle(Settings.processManipulableOnly, "Process manipulable-only parts");
             Settings.limitSize = GUILayout.Toggle(Settings.limitSize, "Limit Size");
-            Settings.stackParts = GUILayout.Toggle(Settings.stackParts, "Stack Parts");
 
-            GUILayout.BeginHorizontal();
-            GUILayout.Label("Filler (" + (Settings.filler * 100).ToString("F0") + "%):");
-            GUILayout.FlexibleSpace();
-            Settings.filler = GUILayout.HorizontalSlider(Settings.filler, 0, 1, GUILayout.Width(250));
-            GUILayout.EndHorizontal();
-
-            GUILayout.BeginHorizontal();
-            GUILayout.Label("Science Filler (" + (Settings.scienceFiller * 100).ToString("F0") + "%):");
-            GUILayout.FlexibleSpace();
-            Settings.scienceFiller = GUILayout.HorizontalSlider(Settings.scienceFiller, 0, 1, GUILayout.Width(250));
-            GUILayout.EndHorizontal();
-
-            GUILayout.BeginHorizontal();
-            GUILayout.Label("Engine Filler (" + (Settings.engineFiller * 100).ToString("F0") + "%):");
-            GUILayout.FlexibleSpace();
-            Settings.engineFiller = GUILayout.HorizontalSlider(Settings.engineFiller, 0, 1, GUILayout.Width(250));
-            GUILayout.EndHorizontal();
-
-            GUILayout.BeginHorizontal();
-            GUILayout.Label("RCS Filler (" + (Settings.rcsFiller * 100).ToString("F0") + "%):");
-            GUILayout.FlexibleSpace();
-            Settings.rcsFiller = GUILayout.HorizontalSlider(Settings.rcsFiller, 0, 1, GUILayout.Width(250));
-            GUILayout.EndHorizontal();
             if (Settings.limitSize)
             {
                 GUILayout.BeginHorizontal();
+                GUILayout.Space(50);
                 GUILayout.Label("Largest Allowable Part: ");
                 var s = GUILayout.TextField(Settings.largestAllowablePart.ToString("F0"), GUILayout.Width(75));
                 GUILayout.Label(" liters");
@@ -101,30 +111,31 @@ namespace KSP_PartVolume
                 GUILayout.EndHorizontal();
             }
 
+            Settings.stackParts = GUILayout.Toggle(Settings.stackParts, "Allow Stackable Parts");
+
             if (Settings.stackParts)
             {
+                GUILayout.BeginHorizontal();
+                GUILayout.Space(50);
+                GUILayout.Label("Max Common Stack Volume: ");
+                var t1 = GUILayout.TextField(Settings.maxCommonStackVolume.ToString("F0"), GUILayout.Width(50));
+                GUILayout.Label(" liters");
+                if (float.TryParse(t1, out float f))
                 {
-                    GUILayout.BeginHorizontal();
-                    GUILayout.Label("Max Common Stack Volume: ");
-                    var s = GUILayout.TextField(Settings.maxCommonStackVolume.ToString("F0"), GUILayout.Width(50));
-                    GUILayout.Label(" liters");
-                    if (float.TryParse(s, out float f))
-                    {
-                        Settings.maxCommonStackVolume = f;
-                    }
-                    GUILayout.EndHorizontal();
+                    Settings.maxCommonStackVolume = f;
                 }
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Space(50);
+                GUILayout.Label("Max Parts In Stack: ");
+                var t2 = GUILayout.TextField(Settings.maxPartsInStack.ToString(), GUILayout.Width(50));
+                GUILayout.Label("");
+                if (int.TryParse(t2, out int i))
                 {
-                    GUILayout.BeginHorizontal();
-                    GUILayout.Label("Max Parts In Stack: ");
-                    var s = GUILayout.TextField(Settings.maxPartsInStack.ToString(), GUILayout.Width(50));
-                    GUILayout.Label("");
-                    if (int.TryParse(s, out int i))
-                    {
-                        Settings.maxPartsInStack = i;
-                    }
-                    GUILayout.EndHorizontal();
+                    Settings.maxPartsInStack = i;
                 }
+                GUILayout.EndHorizontal();
             }
 
             GUILayout.Space(20);


### PR DESCRIPTION
* add stackable support:  
   parts, that is fitted at least two times in *maxStackCommonVolume*, have stackableQuantity, but no more than *maxPartsInStack*
 * add packedVolume to ModuleCargoPart Bypass reasons info
 * change patch, so an index of ModuleCargoPart is not changed
 * support blacklistRegexPattern, and move KerbalEVA there
 * update settings window (checkbox for all fillers)
 ![](https://i.imgur.com/iAVtgdY.jpeg)
