### PR TITLE
Blacklist breaking ground deployable experiments

### DIFF
--- a/GameData/KSP_PartVolume/PartBlacklist.cfg
+++ b/GameData/KSP_PartVolume/PartBlacklist.cfg
@@ -23,4 +23,14 @@ PARTVOLUME_BLACKLIST
 	blacklistRegexPattern = ^nesdCFH.*$
 
 	blacklistModDir = UmbraSpaceIndustries
+
+ 	//Deployed experiments
+  	blacklistPart = DeployedCentralStation
+  	blacklistPart = DeployedGoExOb
+  	blacklistPart = DeployedIONExp
+  	blacklistPart = DeployedRTG
+  	blacklistPart = DeployedSatDish
+  	blacklistPart = DeployedSeismicSensor
+  	blacklistPart = DeployedSolarPanel
+  	blacklistPart = DeployedWeatherStn
 }


### PR DESCRIPTION
Blacklists all the deployable experiments from breaking ground
Made because a user on Discord stated that these experiments broke after PartVolume gave them ModuleCargoPart.
The bug has not been confirmed by me, but this should correct it nonetheless.